### PR TITLE
Pass the Piwik authentication token to the Joinup UAT environment

### DIFF
--- a/cloudformation/single-server.template
+++ b/cloudformation/single-server.template
@@ -59,6 +59,10 @@
     "GithubSSHKeys": {
       "Type": "String",
       "Description": "Comma separated list of Github user names for SSH public keys"
+    },
+    "PiwikAuthenticationToken": {
+      "Type": "String",
+      "Description": "The authentication token of the Piwik server"
     }
   },
   "Mappings": {
@@ -288,6 +292,12 @@
                 "echo 'deploy.groupName=",
                 {
                   "Ref": "env"
+                },
+                "' >> /usr/local/etc/subsite/subsite.tmp.ini",
+                "\n",
+                "echo 'piwik.token=",
+                {
+                  "Ref": "PiwikAuthenticationToken"
                 },
                 "' >> /usr/local/etc/subsite/subsite.tmp.ini",
                 "\n",


### PR DESCRIPTION
We are going to connect to the Piwik test server on our UAT environment so we can start testing the Piwik integration. We need to pass the Piwik authentication token in a secure manner to the UAT servers.

I am declaring a new `PiwikAuthenticationToken` parameter which will be saved in the `subsite.ini` file that contains the overridden Phing properties which are used in the install script. Is this enough to make this work?

The token needs to be configured in the cloud formation UI as well.